### PR TITLE
Improve RGBO regex

### DIFF
--- a/src/color-finder.ts
+++ b/src/color-finder.ts
@@ -8,7 +8,7 @@
  * }}
  */
 export async function findFromRGBO(txt: string) {
-    const regEx = /Color\.fromRGBO\((\d+, \d+, \d+, \d+\.\d+)\)/g;
+    const regEx = /Color\.fromRGBO\((\d{1,3}, \d{1,3}, \d{1,3}, \d{1,3}(\.\d)?)\)/g;
     let result = [];
 
     let match;


### PR DESCRIPTION
- Allows opacity to be 0 or 1 without decimal value;
- Check that the number of digits is between 1 and 3.